### PR TITLE
Load zone.js polyfill in Angular workspace

### DIFF
--- a/app/routers/faces.py
+++ b/app/routers/faces.py
@@ -18,12 +18,12 @@ router = APIRouter(prefix="/faces", tags=["faces"])
 
 @router.post("/enroll", response_model=FaceEnrollmentResponse)
 async def enroll_face(
+    background_tasks: BackgroundTasks,
     name: Annotated[str, Form(...)],
     email: Annotated[str, Form(...)],
     password: Annotated[str, Form(...)],
     files: List[UploadFile] = File(...),
     session: Session = Depends(get_session),
-    background_tasks: BackgroundTasks,
 ) -> FaceEnrollmentResponse:
     user = session.query(User).filter(User.email == email).first()
     if not user:

--- a/frontend/smart-security/angular.json
+++ b/frontend/smart-security/angular.json
@@ -15,7 +15,7 @@
             "outputPath": "dist/smart-security",
             "index": "src/index.html",
             "main": "src/main.ts",
-            "polyfills": [],
+            "polyfills": ["src/polyfills.ts"],
             "tsConfig": "tsconfig.app.json",
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["src/styles.scss"],
@@ -52,7 +52,7 @@
             "main": "src/test.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "polyfills": []
+            "polyfills": ["src/polyfills.ts"]
           }
         }
       }

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from app.database.session import session_scope
 from app.models.security import Device, User
 from app.utils.security import get_password_hash

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import argparse
 
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 from app.services.face_recognition import face_service
 
 


### PR DESCRIPTION
## Summary
- configure the Angular workspace to bundle `src/polyfills.ts` so Zone.js loads during both the build and test targets
- update `scripts/seed_demo.py` to add the project root to `sys.path`, allowing the script to import `app`

## Testing
- npm install *(fails: registry access returns HTTP 403 in this environment)*
- python -m compileall scripts/seed_demo.py

------
https://chatgpt.com/codex/tasks/task_e_68cb23667130832a926c077ca9cc28c7